### PR TITLE
add unit tests for ignoring LongParameterList for function/constructo…

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -123,6 +123,8 @@ complexity:
     ignoreDefaultParameters: false
     ignoreDataClasses: true
     ignoreAnnotatedParameter: []
+    ignoreAnnotatedFunctions: []
+    ignoreAnnotatedConstructors: []
   MethodOverloading:
     active: false
     threshold: 6

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
@@ -70,7 +70,8 @@ class LongParameterList(config: Config = Config.empty) : Rule(config) {
     private val ignoreAnnotatedFunctions: List<String> by config(emptyList())
 
     @Configuration(
-        "ignore annotated constructors from the check (e.g. `data class MyClass @Something constructor(...)` would not be checked)"
+        "ignore annotated constructors from the check " +
+            "(e.g. `data class MyClass @Something constructor(...)` would not be checked)"
     )
     private val ignoreAnnotatedConstructors: List<String> by config(emptyList())
 
@@ -121,7 +122,6 @@ class LongParameterList(config: Config = Config.empty) : Rule(config) {
 
     private fun checkLongParameterList(function: KtFunction, threshold: Int, identifier: String) {
         if (function.isOverride()) return
-
         val parameterList = function.valueParameterList ?: return
         val parameterNumber = parameterList.parameterCount()
 

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
@@ -99,6 +99,8 @@ class LongParameterListSpec : Spek({
             val config by memoized {
                 TestConfig(
                     mapOf(
+                        "ignoreAnnotatedConstructors" to listOf("com.test.Composable"),
+                        "ignoreAnnotatedFunctions" to listOf("com.test.Composable"),
                         "ignoreAnnotatedParameter" to listOf(
                             "Generated",
                             "kotlin.Deprecated",
@@ -137,6 +139,29 @@ class LongParameterListSpec : Spek({
                 val code = "class Data constructor(@kotlin.Suppress(\"\") val a: Int)"
                 assertThat(rule.compileAndLint(code)).isEmpty()
             }
+
+            it("does not report long parameter list for functions if function is annotated with ignored annotation") {
+                val code = """
+                    import com.test.Composable
+                    @Target(AnnotationTarget.FUNCTION)
+                    annotation class Composable
+
+                    @Composable fun foo(a: Int) {} 
+                """
+                assertThat(rule.compileAndLint(code)).isEmpty()
+            }
+
+            it("does not report long parameter list for constructor is annotated with ignored annotation") {
+                val code = """
+                    import com.test.Composable
+                    @Target(AnnotationTarget.CONSTRUCTOR)
+                    annotation class Composable
+
+                    class Data @Composable constructor(val a: Int)
+                """
+                assertThat(rule.compileAndLint(code)).isEmpty()
+            }
+
 
             it("does not report long parameter list for functions if enough function parameters are annotated with ignored annotation") {
                 val code = """class Data {


### PR DESCRIPTION
add unit tests for ignoring LongParameterList for functions/constructors with configured annotations

